### PR TITLE
Feat #11 - Create ProductBoxes with DummyData

### DIFF
--- a/src/components/UI/atoms/Like/LikeStyled.tsx
+++ b/src/components/UI/atoms/Like/LikeStyled.tsx
@@ -6,7 +6,7 @@ export const StyledLike = styled.div<LikeProps>`
   /* align-items: center; */
   gap: 3px;
   span {
-    color: ${(props) => props.theme.$black70};
+    color: ${(props) => props.theme.$black60};
     font-size: 0.95rem;
   }
   svg {

--- a/src/components/UI/molecules/ProductBox/ProductBox.stories.tsx
+++ b/src/components/UI/molecules/ProductBox/ProductBox.stories.tsx
@@ -16,4 +16,15 @@ const Template: Story<ProductBoxProps> = (args) => (
 );
 
 export const Default = Template.bind({});
-Default.args = {};
+Default.args = {
+  product: {
+    id: 1,
+    title: '아이폰 팔아요',
+    imgUrl:
+      'https://dnvefa72aowie.cloudfront.net/origin/article/202201/300ec7e016841850b703e391d7b276f9198c54e7075a32df5a80b6fdd8563a6b.webp?q=82&s=300x300&t=crop',
+    location: '대연동',
+    created_at: new Date(),
+    price: 300000,
+    likes: [1, 2, 3, 4, 5],
+  },
+};

--- a/src/components/UI/molecules/ProductBox/ProductBox.tsx
+++ b/src/components/UI/molecules/ProductBox/ProductBox.tsx
@@ -2,28 +2,28 @@ import Image from '../../atoms/Image/Image';
 import Like from '../../atoms/Like/Like';
 import Time from '../../atoms/Time/Time';
 import Title from '../../atoms/Title/Title';
+import { IProduct } from '../../organisms/ProductBoxes/ProductBoxes';
 import { StyledProductBox } from './ProductBoxStyled';
 
-const dummyImageUrl =
-  'https://dnvefa72aowie.cloudfront.net/origin/article/202201/300ec7e016841850b703e391d7b276f9198c54e7075a32df5a80b6fdd8563a6b.webp?q=82&s=300x300&t=crop';
+export interface ProductBoxProps {
+  product: IProduct;
+}
 
-export interface ProductBoxProps {}
-
-const ProductBox = () => {
+const ProductBox = ({ product }: ProductBoxProps) => {
   return (
     <>
       <StyledProductBox>
-        <Image imgUrl={dummyImageUrl} />
+        <Image imgUrl={product.imgUrl} />
         <div className="product_info">
-          <Title>아이폰 팔아요</Title>
+          <Title>{product.title}</Title>
           <div className="product_info__detail">
-            <span className="product_info__detail-location">대연동 &#183;</span>
-            <Time time={new Date()} />
+            <span className="product_info__detail-location">{product.location} &#183;</span>
+            <Time time={product.created_at} />
           </div>
-          <span className="product_info__price">300,000원</span>
+          <span className="product_info__price">{product.price.toLocaleString('ko-KR')}원</span>
         </div>
         <div className="product_state">
-          <Like count={12} />
+          <Like count={product.likes.length} />
         </div>
       </StyledProductBox>
     </>

--- a/src/components/UI/molecules/ProductBox/ProductBoxStyled.tsx
+++ b/src/components/UI/molecules/ProductBox/ProductBoxStyled.tsx
@@ -1,9 +1,10 @@
 import styled from '@emotion/styled';
-import { ProductBoxProps } from './ProductBox';
 
-export const StyledProductBox = styled.div<ProductBoxProps>`
+export const StyledProductBox = styled.div`
   width: 100%;
   display: flex;
+  padding: 10px 0;
+  border-bottom: 1px solid ${(props) => props.theme.$black20};
   .product_info {
     flex: 1;
     margin-left: 10px;

--- a/src/components/UI/organisms/ProductBoxes/ProductBoxes.stories.tsx
+++ b/src/components/UI/organisms/ProductBoxes/ProductBoxes.stories.tsx
@@ -1,0 +1,16 @@
+import { Meta, Story } from '@storybook/react';
+import ProductBoxes, { ProductBoxesProps } from './ProductBoxes';
+
+export default {
+  title: 'Organisms/ProductBoxes',
+  component: ProductBoxes,
+} as Meta;
+
+const Template: Story<ProductBoxesProps> = (args) => (
+  <>
+    <ProductBoxes {...args} />
+  </>
+);
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/src/components/UI/organisms/ProductBoxes/ProductBoxes.tsx
+++ b/src/components/UI/organisms/ProductBoxes/ProductBoxes.tsx
@@ -1,0 +1,45 @@
+import ProductBox from '../../molecules/ProductBox/ProductBox';
+import { StyledProductBoxes } from './ProductBoxesStyled';
+
+export interface IProduct {
+  id: number;
+  title: string;
+  imgUrl: string;
+  location: string;
+  created_at: Date;
+  price: number;
+  likes: number[];
+}
+
+const dummyProduct: IProduct = {
+  id: 1,
+  title: '아이폰 팔아요',
+  imgUrl:
+    'https://dnvefa72aowie.cloudfront.net/origin/article/202201/300ec7e016841850b703e391d7b276f9198c54e7075a32df5a80b6fdd8563a6b.webp?q=82&s=300x300&t=crop',
+  location: '대연동',
+  created_at: new Date(),
+  price: 300000,
+  likes: [1, 2, 3, 4, 5],
+};
+
+const dummyProducts: IProduct[] = Array(10)
+  .fill(dummyProduct)
+  .map((dummyProduct, index) => {
+    const indexDummyProduct = { ...dummyProduct };
+    indexDummyProduct.id = index + 1;
+    return indexDummyProduct;
+  });
+
+export interface ProductBoxesProps {}
+
+const ProductBoxes = (props: ProductBoxesProps) => {
+  return (
+    <StyledProductBoxes>
+      {dummyProducts.map((product) => (
+        <ProductBox key={product.id} product={product} />
+      ))}
+    </StyledProductBoxes>
+  );
+};
+
+export default ProductBoxes;

--- a/src/components/UI/organisms/ProductBoxes/ProductBoxesStyled.tsx
+++ b/src/components/UI/organisms/ProductBoxes/ProductBoxesStyled.tsx
@@ -1,0 +1,6 @@
+import styled from '@emotion/styled';
+
+export const StyledProductBoxes = styled.div`
+  display: flex;
+  flex-direction: column;
+`;


### PR DESCRIPTION
```
const dummyProduct: IProduct = {
  id: 1,
  title: '아이폰 팔아요',
  imgUrl:
    'https://dnvefa72aowie.cloudfront.net/origin/article/202201/300ec7e016841850b703e391d7b276f9198c54e7075a32df5a80b6fdd8563a6b.webp?q=82&s=300x300&t=crop',
  location: '대연동',
  created_at: new Date(),
  price: 300000,
  likes: [1, 2, 3, 4, 5],
};
```
이런식으로 더미데이터 만들어서 했어요 추후에 더미데이터 관리하는 폴더만들어서 관리해줘야 할 것 같아용
추가적으로 
ProductBox에서 props를 
```
export interface ProductBoxProps {
  title: string;
  imgUrl: string;
  location: string;
  created_at: Date;
  price: number;
  likeLength: number;
}
```
이렇게 받는데  나을까요 아니면 
```
export interface ProductBoxProps {
  product: IProduct
}
```
이렇게 하는게 나을까요?? 