### PR TITLE
Feat #28 - Templates/ProductDetail 생성

### DIFF
--- a/src/components/UI/molecules/ProductBox/ProductBox.stories.tsx
+++ b/src/components/UI/molecules/ProductBox/ProductBox.stories.tsx
@@ -20,7 +20,7 @@ Default.args = {
   product: {
     id: 1,
     title: '아이폰 팔아요',
-    imgUrl:
+    thumb_nail_image:
       'https://dnvefa72aowie.cloudfront.net/origin/article/202201/300ec7e016841850b703e391d7b276f9198c54e7075a32df5a80b6fdd8563a6b.webp?q=82&s=300x300&t=crop',
     location: '대연동',
     created_at: new Date(),

--- a/src/components/UI/molecules/ProductBox/ProductBox.tsx
+++ b/src/components/UI/molecules/ProductBox/ProductBox.tsx
@@ -7,14 +7,14 @@ import { IProduct } from '../../organisms/ProductBoxes/ProductBoxes';
 import { StyledProductBox } from './ProductBoxStyled';
 
 export interface ProductBoxProps {
-  product: Pick<IProduct, 'id' | 'imgUrl' | 'title' | 'location' | 'created_at' | 'price' | 'likes'>;
+  product: Pick<IProduct, 'id' | 'thumb_nail_image' | 'title' | 'location' | 'created_at' | 'price' | 'likes'>;
 }
 
 const ProductBox = ({ product }: ProductBoxProps) => {
   return (
     <>
       <StyledProductBox>
-        <Image imgUrl={product.imgUrl} />
+        <Image imgUrl={product.thumb_nail_image} />
         <div className="product_info">
           <Title>{product.title}</Title>
           <div className="product_info__detail">

--- a/src/components/UI/molecules/SellerBox/SellerBox.stories.tsx
+++ b/src/components/UI/molecules/SellerBox/SellerBox.stories.tsx
@@ -14,8 +14,10 @@ const Template: Story<SellerBoxProps> = (args) => (
 
 export const Default = Template.bind({});
 Default.args = {
-  sellerName: "유키링",
-  sellerImgUrl: "https://img1.cgtrader.com/items/3095532/6fb947cfc0/large/hello-kitty-sanrio-3d-model-low-poly-obj-ztl.jpg",
-  location: "하라주쿠",
-  degree: 38.6,
+  sellerDetail: {
+    name: "유키링",
+    profileUrl: "https://img1.cgtrader.com/items/3095532/6fb947cfc0/large/hello-kitty-sanrio-3d-model-low-poly-obj-ztl.jpg",
+    location: "하라주쿠",
+    manner: 38.6,
+  },
 };

--- a/src/components/UI/molecules/SellerBox/SellerBox.tsx
+++ b/src/components/UI/molecules/SellerBox/SellerBox.tsx
@@ -1,25 +1,23 @@
 import Image from '../../atoms/Image/Image';
 import Temperature from '../../atoms/Temperature/Temperature';
 import { SellerBoxStyled } from './SellerBoxStyled';
+import { ISeller } from '../../organisms/DetailBox/DetailBox';
 
 export interface SellerBoxProps {
-  sellerName: string;
-  sellerImgUrl: string;
-  location: string;
-  degree: number;
+  sellerDetail: Pick<ISeller, 'name' | 'profileUrl' | 'location' | 'manner'>;
 }
 
-const SellerBox = (props: SellerBoxProps) => {
+const SellerBox = ({ sellerDetail }: SellerBoxProps) => {
   return (
     <>
-      <SellerBoxStyled {...props}>
-        <Image imgUrl={props.sellerImgUrl} width="40px" height="40px" borderRedius="50%" />
+      <SellerBoxStyled {...sellerDetail}>
+        <Image imgUrl={sellerDetail.profileUrl} width="40px" height="40px" borderRedius="50%" />
         <div className="seller-inform">
-          <p className="seller-inform_name">{props.sellerName}</p>
-          <p className="seller-inform_location">{props.location}</p>
+          <p className="seller-inform_name">{sellerDetail.name}</p>
+          <p className="seller-inform_location">{sellerDetail.location}</p>
         </div>
         <div className="seller-temperature">
-          <Temperature type="product" degree={props.degree} />
+          <Temperature type="product" degree={sellerDetail.manner} />
         </div>
       </SellerBoxStyled>
     </>

--- a/src/components/UI/molecules/SellerBox/SellerBoxStyled.tsx
+++ b/src/components/UI/molecules/SellerBox/SellerBoxStyled.tsx
@@ -1,10 +1,10 @@
 import styled from "@emotion/styled";
 import { SellerBoxProps } from "./SellerBox";
 
-export const SellerBoxStyled = styled.div<SellerBoxProps>`
+export const SellerBoxStyled = styled.div`
   width: 100%;
   display: flex;
-  padding: 10px;
+  padding: 10px 0px;
   overflow-x: hidden;
   border-bottom: 1px solid ${(props) => props.theme.$black20};
   .seller-inform {

--- a/src/components/UI/molecules/Slider/Slider.stories.tsx
+++ b/src/components/UI/molecules/Slider/Slider.stories.tsx
@@ -14,5 +14,7 @@ const Template: Story<SliderProps> = (args) => (
 
 export const Default = Template.bind({});
 Default.args = {
-  slideImages: ["https://play-lh.googleusercontent.com/6Adeoocj4FktXRmkcFY8j6sknDBK_eoCjsMv6EPJI_ZLhLUeAmZH_r5QxKBBa8xoxgni", "https://img.pixers.pics/pho(s3:700/PI/23/28/700_PI2328_929d479296b1a4e351ad083979e06dca_5b7aba17b76ce_.,700,700,jpg)/shower-curtains-hello-kitty.jpg.jpg", "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR3he9XCrjKds0D-MuWkEmH9NEk3NjxMBqZTOgXwSBT4DZu2RX6-T-ZNFfEXtnIHnMuuCQ&usqp=CAU"],
+  slides: {
+    images: ["https://play-lh.googleusercontent.com/6Adeoocj4FktXRmkcFY8j6sknDBK_eoCjsMv6EPJI_ZLhLUeAmZH_r5QxKBBa8xoxgni", "https://img.pixers.pics/pho(s3:700/PI/23/28/700_PI2328_929d479296b1a4e351ad083979e06dca_5b7aba17b76ce_.,700,700,jpg)/shower-curtains-hello-kitty.jpg.jpg", "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR3he9XCrjKds0D-MuWkEmH9NEk3NjxMBqZTOgXwSBT4DZu2RX6-T-ZNFfEXtnIHnMuuCQ&usqp=CAU"],
+  },
 };

--- a/src/components/UI/molecules/Slider/Slider.tsx
+++ b/src/components/UI/molecules/Slider/Slider.tsx
@@ -1,14 +1,15 @@
 import { useState, useEffect, useRef } from "react"; 
 import SlideButton from "../../atoms/SlideButton/SlideButton";
 import Image from "../../atoms/Image/Image";
+import { IProduct } from "../../organisms/ProductBoxes/ProductBoxes";
 import { SliderStyled } from './SliderStyled';
 
 export interface SliderProps {
-  slideImages: string[];
+  slides: Pick<IProduct, 'images'>;
 }
 
-const Slider = (props: SliderProps) => {
-  const TOTAL_SLIDES = props.slideImages.length - 1;
+const Slider = ({ slides }: SliderProps) => {
+  const TOTAL_SLIDES = slides.images.length - 1;
   const [currentSlide, setCurrentSlide] = useState(0);
 
   const slideRef = useRef() as React.MutableRefObject<HTMLDivElement>;
@@ -30,11 +31,11 @@ const Slider = (props: SliderProps) => {
 
   return (
     <>
-      <SliderStyled {...props}>
+      <SliderStyled {...slides}>
         <SlideButton direction="previous" onClick={prevSlide} />
         <SlideButton direction="next" onClick={nextSlide} />
         <div className="slider-container" ref={slideRef}>
-        {props.slideImages.map((slide, idx) =>
+        {slides.images.map((slide, idx) =>
           <div className="slide" key={idx} >
             <Image
               imgUrl={slide}

--- a/src/components/UI/molecules/Slider/SliderStyled.tsx
+++ b/src/components/UI/molecules/Slider/SliderStyled.tsx
@@ -1,7 +1,6 @@
 import styled from "@emotion/styled";
-import { SliderProps } from "./Slider";
 
-export const SliderStyled = styled.div<SliderProps>`
+export const SliderStyled = styled.div`
   width: 100%;
   overflow: hidden;
   position: relative;

--- a/src/components/UI/organisms/DetailBox/DetailBox.stories.tsx
+++ b/src/components/UI/organisms/DetailBox/DetailBox.stories.tsx
@@ -14,7 +14,9 @@ const Template: Story<DetailBoxProps> = (args) => (
 
 export const Default = Template.bind({});
 Default.args = {
-  slideImages: ["https://play-lh.googleusercontent.com/6Adeoocj4FktXRmkcFY8j6sknDBK_eoCjsMv6EPJI_ZLhLUeAmZH_r5QxKBBa8xoxgni", "https://img.pixers.pics/pho(s3:700/PI/23/28/700_PI2328_929d479296b1a4e351ad083979e06dca_5b7aba17b76ce_.,700,700,jpg)/shower-curtains-hello-kitty.jpg.jpg", "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR3he9XCrjKds0D-MuWkEmH9NEk3NjxMBqZTOgXwSBT4DZu2RX6-T-ZNFfEXtnIHnMuuCQ&usqp=CAU"],
+  slides: {
+    images: ["https://play-lh.googleusercontent.com/6Adeoocj4FktXRmkcFY8j6sknDBK_eoCjsMv6EPJI_ZLhLUeAmZH_r5QxKBBa8xoxgni", "https://img.pixers.pics/pho(s3:700/PI/23/28/700_PI2328_929d479296b1a4e351ad083979e06dca_5b7aba17b76ce_.,700,700,jpg)/shower-curtains-hello-kitty.jpg.jpg", "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR3he9XCrjKds0D-MuWkEmH9NEk3NjxMBqZTOgXwSBT4DZu2RX6-T-ZNFfEXtnIHnMuuCQ&usqp=CAU"],
+  },
   sellerDetail: {
     name: "유키링",
     profileUrl: "https://img1.cgtrader.com/items/3095532/6fb947cfc0/large/hello-kitty-sanrio-3d-model-low-poly-obj-ztl.jpg",

--- a/src/components/UI/organisms/DetailBox/DetailBox.stories.tsx
+++ b/src/components/UI/organisms/DetailBox/DetailBox.stories.tsx
@@ -1,0 +1,33 @@
+import { Meta, Story } from "@storybook/react";
+import DetailBox, { DetailBoxProps } from "./DetailBox";
+
+export default {
+  title: 'Organisms/DetailBox',
+  component: DetailBox,
+} as Meta;
+
+const Template: Story<DetailBoxProps> = (args) => (
+  <>
+    <DetailBox {...args} />
+  </>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  slideImages: ["https://play-lh.googleusercontent.com/6Adeoocj4FktXRmkcFY8j6sknDBK_eoCjsMv6EPJI_ZLhLUeAmZH_r5QxKBBa8xoxgni", "https://img.pixers.pics/pho(s3:700/PI/23/28/700_PI2328_929d479296b1a4e351ad083979e06dca_5b7aba17b76ce_.,700,700,jpg)/shower-curtains-hello-kitty.jpg.jpg", "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR3he9XCrjKds0D-MuWkEmH9NEk3NjxMBqZTOgXwSBT4DZu2RX6-T-ZNFfEXtnIHnMuuCQ&usqp=CAU"],
+  sellerDetail: {
+    name: "유키링",
+    profileUrl: "https://img1.cgtrader.com/items/3095532/6fb947cfc0/large/hello-kitty-sanrio-3d-model-low-poly-obj-ztl.jpg",
+    location: "하라주쿠",
+    manner: 38.6,
+  },
+  productDetail: {
+    title: '아이폰 삽니다',
+    category: '디지털기기',
+    description: '원가 18,900갤럭시로 갈아타면서 판매해요~ 한번도 사용안한 새상품입니다',
+    created_at: new Date(),
+    view: 256,
+    favorite: 21,
+    chat: 4,
+  },
+};

--- a/src/components/UI/organisms/DetailBox/DetailBox.tsx
+++ b/src/components/UI/organisms/DetailBox/DetailBox.tsx
@@ -1,0 +1,31 @@
+import Slider from '../../molecules/Slider/Slider';
+import SellerBox from '../../molecules/SellerBox/SellerBox';
+import DescriptionBox from '../../molecules/DescriptionBox/DescriptionBox';
+import { IProduct } from '../../organisms/ProductBoxes/ProductBoxes';
+import { DetailBoxStyled } from './DetailBoxStyled';
+
+export interface ISeller {
+  name: string;
+  profileUrl: string;
+  location: string;
+  manner: number;
+}
+
+export interface DetailBoxProps {
+  slideImages: string[];
+  sellerDetail: Pick<ISeller, 'name' | 'profileUrl' | 'location' | 'manner'>;
+  productDetail: Pick<IProduct, 'category' | 'chat' | 'created_at' | 'description' | 'favorite' | 'title' | 'view'>;
+}
+
+const DetailBox = (props : DetailBoxProps) => {
+  return (
+    <>
+      <DetailBoxStyled {...props}>
+        <Slider {...props} />
+        <SellerBox {...props} />
+        <DescriptionBox {...props} />
+      </DetailBoxStyled>
+    </>
+  );
+};
+export default DetailBox;

--- a/src/components/UI/organisms/DetailBox/DetailBox.tsx
+++ b/src/components/UI/organisms/DetailBox/DetailBox.tsx
@@ -21,7 +21,9 @@ const DetailBox = (props : DetailBoxProps) => {
   return (
     <>
       <DetailBoxStyled {...props}>
-        <Slider {...props} />
+        <div className='slider-wrap'>
+          <Slider {...props} />
+        </div>
         <SellerBox {...props} />
         <DescriptionBox {...props} />
       </DetailBoxStyled>

--- a/src/components/UI/organisms/DetailBox/DetailBox.tsx
+++ b/src/components/UI/organisms/DetailBox/DetailBox.tsx
@@ -12,7 +12,7 @@ export interface ISeller {
 }
 
 export interface DetailBoxProps {
-  slideImages: string[];
+  slides: Pick<IProduct, 'images'>;
   sellerDetail: Pick<ISeller, 'name' | 'profileUrl' | 'location' | 'manner'>;
   productDetail: Pick<IProduct, 'category' | 'chat' | 'created_at' | 'description' | 'favorite' | 'title' | 'view'>;
 }

--- a/src/components/UI/organisms/DetailBox/DetailBoxStyled.tsx
+++ b/src/components/UI/organisms/DetailBox/DetailBoxStyled.tsx
@@ -1,0 +1,5 @@
+import styled from "@emotion/styled";
+import { DetailBoxProps } from "./DetailBox";
+
+export const DetailBoxStyled = styled.div<DetailBoxProps>`
+`;

--- a/src/components/UI/organisms/DetailBox/DetailBoxStyled.tsx
+++ b/src/components/UI/organisms/DetailBox/DetailBoxStyled.tsx
@@ -2,4 +2,7 @@ import styled from "@emotion/styled";
 import { DetailBoxProps } from "./DetailBox";
 
 export const DetailBoxStyled = styled.div<DetailBoxProps>`
+  .slider-wrap {
+    margin: -17px -16px 8px -16px;
+  }
 `;

--- a/src/components/UI/organisms/ProductBoxes/ProductBoxes.tsx
+++ b/src/components/UI/organisms/ProductBoxes/ProductBoxes.tsx
@@ -5,7 +5,8 @@ export interface IProduct {
   id: number;
   title: string;
   category: string;
-  imgUrl: string;
+  thumb_nail_image: string;
+  images: string[];
   location: string;
   created_at: Date;
   price: number;
@@ -19,7 +20,7 @@ export interface IProduct {
 const dummyProduct: Partial<IProduct> = {
   id: 1,
   title: '아이폰 팔아요',
-  imgUrl:
+  thumb_nail_image:
     'https://dnvefa72aowie.cloudfront.net/origin/article/202201/300ec7e016841850b703e391d7b276f9198c54e7075a32df5a80b6fdd8563a6b.webp?q=82&s=300x300&t=crop',
   location: '대연동',
   created_at: new Date(),

--- a/src/components/templates/ProductDetail/ProductDetail.stories.tsx
+++ b/src/components/templates/ProductDetail/ProductDetail.stories.tsx
@@ -14,7 +14,9 @@ const Template: Story<ProductDetailProps> = (args) => (
 
 export const Default = Template.bind({});
 Default.args = {
-  slideImages: ["https://play-lh.googleusercontent.com/6Adeoocj4FktXRmkcFY8j6sknDBK_eoCjsMv6EPJI_ZLhLUeAmZH_r5QxKBBa8xoxgni", "https://img.pixers.pics/pho(s3:700/PI/23/28/700_PI2328_929d479296b1a4e351ad083979e06dca_5b7aba17b76ce_.,700,700,jpg)/shower-curtains-hello-kitty.jpg.jpg", "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR3he9XCrjKds0D-MuWkEmH9NEk3NjxMBqZTOgXwSBT4DZu2RX6-T-ZNFfEXtnIHnMuuCQ&usqp=CAU"],
+  slides: {
+    images: ["https://play-lh.googleusercontent.com/6Adeoocj4FktXRmkcFY8j6sknDBK_eoCjsMv6EPJI_ZLhLUeAmZH_r5QxKBBa8xoxgni", "https://img.pixers.pics/pho(s3:700/PI/23/28/700_PI2328_929d479296b1a4e351ad083979e06dca_5b7aba17b76ce_.,700,700,jpg)/shower-curtains-hello-kitty.jpg.jpg", "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR3he9XCrjKds0D-MuWkEmH9NEk3NjxMBqZTOgXwSBT4DZu2RX6-T-ZNFfEXtnIHnMuuCQ&usqp=CAU"],
+  },
   sellerDetail: {
     name: "유키링",
     profileUrl: "https://img1.cgtrader.com/items/3095532/6fb947cfc0/large/hello-kitty-sanrio-3d-model-low-poly-obj-ztl.jpg",

--- a/src/components/templates/ProductDetail/ProductDetail.stories.tsx
+++ b/src/components/templates/ProductDetail/ProductDetail.stories.tsx
@@ -1,0 +1,35 @@
+import { Meta, Story } from "@storybook/react";
+import ProductDetail, { ProductDetailProps } from "./ProductDetail";
+
+export default {
+  title: 'Templates/ProductDetail',
+  component: ProductDetail,
+} as Meta;
+
+const Template: Story<ProductDetailProps> = (args) => (
+  <>
+    <ProductDetail {...args} />
+  </>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  slideImages: ["https://play-lh.googleusercontent.com/6Adeoocj4FktXRmkcFY8j6sknDBK_eoCjsMv6EPJI_ZLhLUeAmZH_r5QxKBBa8xoxgni", "https://img.pixers.pics/pho(s3:700/PI/23/28/700_PI2328_929d479296b1a4e351ad083979e06dca_5b7aba17b76ce_.,700,700,jpg)/shower-curtains-hello-kitty.jpg.jpg", "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR3he9XCrjKds0D-MuWkEmH9NEk3NjxMBqZTOgXwSBT4DZu2RX6-T-ZNFfEXtnIHnMuuCQ&usqp=CAU"],
+  sellerDetail: {
+    name: "유키링",
+    profileUrl: "https://img1.cgtrader.com/items/3095532/6fb947cfc0/large/hello-kitty-sanrio-3d-model-low-poly-obj-ztl.jpg",
+    location: "하라주쿠",
+    manner: 38.6,
+  },
+  productDetail: {
+    title: '아이폰 삽니다',
+    category: '디지털기기',
+    description: '원가 18,900갤럭시로 갈아타면서 판매해요~ 한번도 사용안한 새상품입니다',
+    created_at: new Date(),
+    view: 256,
+    favorite: 21,
+    chat: 4,
+  },
+  isLike: true,
+  productPrice: 6000,
+};

--- a/src/components/templates/ProductDetail/ProductDetail.tsx
+++ b/src/components/templates/ProductDetail/ProductDetail.tsx
@@ -1,0 +1,27 @@
+import DetailTabBar from '../../UI/molecules/DetailTabBar/DetailTabBar';
+import DetailBox from '../../UI/organisms/DetailBox/DetailBox';
+import DealBox from '../../UI/molecules/DealBox/DealBox';
+import { ISeller } from '../../UI/organisms/DetailBox/DetailBox';
+import { IProduct } from '../../UI/organisms/ProductBoxes/ProductBoxes';
+import { ProductDetailStyled } from './ProductDetailStyled';
+
+export interface ProductDetailProps {
+  slideImages: string[];
+  sellerDetail: Pick<ISeller, 'name' | 'profileUrl' | 'location' | 'manner'>;
+  productDetail: Pick<IProduct, 'category' | 'chat' | 'created_at' | 'description' | 'favorite' | 'title' | 'view'>;
+  isLike: true,
+  productPrice: 6000,
+}
+
+const ProductDetail = (props : ProductDetailProps) => {
+  return (
+    <>
+      <ProductDetailStyled {...props}>
+        <DetailTabBar />
+        <DetailBox {...props} />
+        <DealBox {...props} />
+      </ProductDetailStyled>
+    </>
+  );
+};
+export default ProductDetail;

--- a/src/components/templates/ProductDetail/ProductDetail.tsx
+++ b/src/components/templates/ProductDetail/ProductDetail.tsx
@@ -6,7 +6,7 @@ import { IProduct } from '../../UI/organisms/ProductBoxes/ProductBoxes';
 import { ProductDetailStyled } from './ProductDetailStyled';
 
 export interface ProductDetailProps {
-  slideImages: string[];
+  slides: Pick<IProduct, 'images'>;
   sellerDetail: Pick<ISeller, 'name' | 'profileUrl' | 'location' | 'manner'>;
   productDetail: Pick<IProduct, 'category' | 'chat' | 'created_at' | 'description' | 'favorite' | 'title' | 'view'>;
   isLike: true,

--- a/src/components/templates/ProductDetail/ProductDetailStyled.tsx
+++ b/src/components/templates/ProductDetail/ProductDetailStyled.tsx
@@ -1,0 +1,5 @@
+import styled from "@emotion/styled";
+import { ProductDetailProps } from "./ProductDetail";
+
+export const ProductDetailStyled = styled.div<ProductDetailProps>`
+`;


### PR DESCRIPTION
```typescript
export interface IProduct {
  id: number;
  title: string;
  category: string;
  imgUrl: string;
  location: string;
  created_at: Date;
  price: number;
  likes: number[];
  description: string;
  view: number;
  favorite: number;
  chat: number;
}
```
재훈님이 만드셨던 IProduct에서 imgUrl이 썸네일 사진이잖아요!

```typescript
export interface ProductDetailProps {
  slideImages: string[];    //Slider에서 보이는 이미지 url들
  sellerDetail: Pick<ISeller, 'name' | 'profileUrl' | 'location' | 'manner'>;
  productDetail: Pick<IProduct, 'category' | 'chat' | 'created_at' | 'description' | 'favorite' | 'title' | 'view'>;
  isLike: true,
  productPrice: 6000,
}
```
이건 이제 제가 ProductDetail 만들면서 생성한 props예요. 그런데 여기서 slideImages가 따로 혼자 있기 보단, productDetail(IProduct) 안에 포함되고, ProductBox 같이 제품의 썸네일 이미지가 필요한 곳에서는 imgUrl 대신 slideImages[0]을 보여주는 것도 괜찮을 거 같은데 재훈님 생각은 어떠신가요!!