### PR TITLE
Issue/#41 자잘한 버그/스타일링 수정

### DIFF
--- a/src/components/UI/atoms/PostButton/PostButtonStyled.tsx
+++ b/src/components/UI/atoms/PostButton/PostButtonStyled.tsx
@@ -2,12 +2,12 @@ import styled from '@emotion/styled';
 import { PostButtonProps } from './PostButton';
 
 export const PostButtonStyled = styled.div<PostButtonProps>`
-  position: fixed;
-  right: 10px;
-  bottom: 50px;
-  z-index: 999999;
   text-align: right;
   button {
+    position: fixed;
+    right: 10px;
+    bottom: 50px;
+    z-index: 999999;
     background: ${(props) => (props.toggle ? 'white' : props.theme.mainColor)};
     border: none;
     border-radius: 50%;
@@ -31,6 +31,10 @@ export const PostButtonStyled = styled.div<PostButtonProps>`
     }
   }
   .modal-box {
+    position: fixed;
+    right: 10px;
+    bottom: 100px;
+    z-index: 999999;
     background: white;
     box-shadow: 0 0 5px rgba(33, 33, 33, 0.1);
     border-radius: 10px;

--- a/src/components/UI/atoms/SlideButton/SlideButtonStyled.tsx
+++ b/src/components/UI/atoms/SlideButton/SlideButtonStyled.tsx
@@ -7,7 +7,7 @@ export const SlideButtonStyled = styled.button<SlideButtonProps>`
   border-radius: 50%;
   position: absolute;
   z-index: 999;
-  top: 45%;
+  top: 48%;
   left: ${(props) => props.direction === "previous" ? "2px" : "none"};
   right: ${(props) => props.direction === "next" ? "2px" : "none"};
   &:hover {

--- a/src/components/UI/atoms/Temperature/TemperatureStyled.tsx
+++ b/src/components/UI/atoms/Temperature/TemperatureStyled.tsx
@@ -5,17 +5,20 @@ export const TemperatureStyled = styled.div<TemperatureProps>`
   color: ${(props) => props.color};
   font-weight: 600;
   width: ${(props) => props.type === 'product' ? "85px" : "100%"};
+  display: inline-flex;
+  flex-direction: column;
   svg {
     stroke: ${(props) => props.color};
     fill: ${(props) => props.color};
   }
   progress { 
     appearance: none;
+    width: auto;
   }
   progress::-webkit-progress-bar { 
     background: ${(props) => props.theme.$black20};
     border-radius: 10px;
-    width: ${(props) => props.type === 'product' ? "50px" : "92vw"};
+    width: ${(props) => props.type === 'product' ? "50px" : "100%"};
     height: 6px;
     margin-top: 3px;
   } 
@@ -46,7 +49,7 @@ export const TemperatureStyled = styled.div<TemperatureProps>`
   .first-temperature {
     width: 66px;
     position: absolute;
-    left: calc((92vw * 0.365) - 33px);
+    left: calc((100% * 0.365) - 33px);
     margin-bottom: -10px;
     .mark {
       color: ${(props) => props.theme.$black60};
@@ -61,7 +64,8 @@ export const TemperatureStyled = styled.div<TemperatureProps>`
     border-radius: 20px;
     padding: 3px 6px;
     display: inline-block;
-    width: auto;
+    text-align: center;
+    width: 51px;
     font-size: 0.68rem;
   }
 `;

--- a/src/components/UI/molecules/Slider/Slider.tsx
+++ b/src/components/UI/molecules/Slider/Slider.tsx
@@ -30,13 +30,18 @@ const Slider = ({ slides }: SliderProps) => {
   return (
     <>
       <SliderStyled {...slides}>
-        <SlideButton direction="previous" onClick={prevSlide} />
-        <SlideButton direction="next" onClick={nextSlide} />
-        <div className="slider-container" ref={slideRef}>
+        <SlideButton direction='previous' onClick={prevSlide} />
+        <SlideButton direction='next' onClick={nextSlide} />
+        <div className='slider-container' ref={slideRef}>
           {slides.images.map((slide, idx) => (
-            <div className="slide" key={idx}>
-              <Image imgUrl={slide} width="100%" height="400px" borderRedius="0px" />
+            <div className='slide' key={idx}>
+              <Image imgUrl={slide} width='100%' height='400px' borderRedius='0px' />
             </div>
+          ))}
+        </div>
+        <div className='slide-index'>
+          {Array(TOTAL_SLIDES + 1).fill(0).map((slide, idx) => (
+            idx === currentSlide ? <div className='current mark' key={idx} /> : <div className='normal mark' key={idx} />
           ))}
         </div>
       </SliderStyled>

--- a/src/components/UI/molecules/Slider/SliderStyled.tsx
+++ b/src/components/UI/molecules/Slider/SliderStyled.tsx
@@ -13,4 +13,25 @@ export const SliderStyled = styled.div`
     object-fit: cover;
     flex-shrink: 0;
   }
+  .slide-index {
+    position: absolute;
+    z-index: 999;
+    bottom: 10px;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    .mark {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: white;
+    }
+    .normal {
+      opacity: 0.6; 
+    }
+    .current {
+      opacity: 1;
+    }
+  }
 `;


### PR DESCRIPTION
## Tempaerature 수정
매너 온도를 가리키기 위해 html 태그인 progress를 사용하고 해당 태그 width로 vw를 사용했었는데, 넓이가 매끄럽게 안늘어나서 수정했어요! 아래 사진에서 상단이 수정 전, 하단이 수정 후 입니다~!
![image](https://user-images.githubusercontent.com/67870795/162150546-c405abe5-71d0-46cc-9b2f-a49347e645a5.png)

## PostButton 수정
ProstButton은 modal의 외부 영역을 클릭하면 "내 물건 팔기" modal이 사라져야 해서 useRef()를 사용했는데, 아래 사진에서 빨간 박스 영역 모두가 ref로 잡혀서 modal 외부 영역임에도 빨간 박스 안이면 modal이 사라지지 않았어서 이 부분 수정했어요!
![image](https://user-images.githubusercontent.com/67870795/162151705-a314d11a-fff2-4b2d-a299-c6d8a83e2400.png)


## Slider 수정
Slider 만들 때 Slider 하단에 총 사진 개수와, 현재 몇번째 slide인지 나타내는 동그라미들을(?) 추가하는 것을 까먹었어서 추가했어요!
![image](https://user-images.githubusercontent.com/67870795/162152522-1b62c75f-27fb-412a-b48a-c7c9010aca4c.png)

