### PR TITLE
Feat #55 - Create Molecules/MessagesPerMinute

### DIFF
--- a/src/components/UI/atoms/ChatMessage/ChatMessage.stories.tsx
+++ b/src/components/UI/atoms/ChatMessage/ChatMessage.stories.tsx
@@ -1,0 +1,51 @@
+import { Meta, Story } from '@storybook/react';
+import ChatMessage, { ChatMessageProps } from './ChatMessage';
+
+export default {
+  title: 'Atoms/ChatMessage',
+  component: ChatMessage,
+} as Meta;
+
+const Template: Story<ChatMessageProps> = (args) => (
+  <>
+    <ChatMessage {...args} />
+  </>
+);
+
+export const Me = Template.bind({});
+Me.args = {
+  chat: {
+    sender: 'me',
+    message: '아 이미 구매했어요 ㅠㅠ 죄송합니당 ㅜㅜㅜㅜ',
+    createdAt: new Date(),
+  },
+};
+
+export const You = Template.bind({});
+You.args = {
+  chat: {
+    sender: 'you',
+    message: '아 이미 구매했어요 ㅠㅠ 죄송합니당 ㅜㅜㅜㅜ',
+    createdAt: new Date(),
+  },
+};
+
+export const MeWithTime = Template.bind({});
+MeWithTime.args = {
+  chat: {
+    sender: 'me',
+    message: '아 이미 구매했어요 ㅠㅠ 죄송합니당 ㅜㅜㅜㅜ',
+    createdAt: new Date(),
+  },
+  minute: true,
+};
+
+export const YouWithTime = Template.bind({});
+YouWithTime.args = {
+  chat: {
+    sender: 'you',
+    message: '아 이미 구매했어요 ㅠㅠ 죄송합니당 ㅜㅜㅜㅜ',
+    createdAt: new Date(),
+  },
+  minute: true,
+};

--- a/src/components/UI/atoms/ChatMessage/ChatMessage.tsx
+++ b/src/components/UI/atoms/ChatMessage/ChatMessage.tsx
@@ -1,0 +1,29 @@
+import { ChatMessageStyled } from './ChatMessageStyled';
+import Time from '@atoms/Time/Time';
+import { IChat } from '@molecules/MessagesPerMinute/MessagesPerMinute';
+
+export interface ChatMessageProps {
+  minute?: boolean; //해당 분에 마지막인지 아닌지 (마지막이면 Time 보여줌)
+  chat: IChat;
+}
+
+const ChatMessage: React.FC<ChatMessageProps> = ({ minute, chat }, props) => {
+  return (
+    <>
+      <ChatMessageStyled {...props}>
+        {chat.sender === 'me' ? (
+          <div className="message-container justify-end">
+            {minute ? <Time time={chat.createdAt} exactTime={true} /> : null}
+            <div className="message-text me">{chat.message}</div>
+          </div>
+        ) : (
+          <div className="message-container justify-start">
+            <div className="message-text you">{chat.message}</div>
+            {minute ? <Time time={chat.createdAt} exactTime={true} /> : null}
+          </div>
+        )}
+      </ChatMessageStyled>
+    </>
+  );
+};
+export default ChatMessage;

--- a/src/components/UI/atoms/ChatMessage/ChatMessageStyled.tsx
+++ b/src/components/UI/atoms/ChatMessage/ChatMessageStyled.tsx
@@ -1,0 +1,37 @@
+import styled from '@emotion/styled';
+import { ChatMessageProps } from './ChatMessage';
+
+export const ChatMessageStyled = styled.div<ChatMessageProps>`
+  .message-container {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-end;
+    margin-bottom: 3px;
+    gap: 3px;
+  }
+  .justify-end {
+    justify-content: flex-end;
+  }
+  .justify-start {
+    justify-content: flex-start;
+  }
+
+  .message-text {
+    display: inline-block;
+    border: none;
+    border-radius: 15px;
+    padding: 10px;
+    width: auto;
+    max-width: 80%;
+    font-size: 0.9rem;
+    word-wrap: break-word;
+  }
+  .me {
+    background: ${(props) => props.theme.mainColor};
+    color: white;
+  }
+  .you {
+    background: ${(props) => props.theme.$black20};
+    color: black;
+  }
+`;

--- a/src/components/UI/atoms/Time/Time.stories.tsx
+++ b/src/components/UI/atoms/Time/Time.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Meta, Story } from '@storybook/react';
 import Time, { TimeProps } from './Time';
 
@@ -9,11 +8,17 @@ export default {
 
 const Template: Story<TimeProps> = (args) => (
   <>
-    <Time {...args}>삼성갤럭시폰 교환해요</Time>
+    <Time {...args} />
   </>
 );
 
 export const Default = Template.bind({});
 Default.args = {
   time: new Date(),
+};
+
+export const ExactTime = Template.bind({});
+ExactTime.args = {
+  time: new Date(),
+  exactTime: true,
 };

--- a/src/components/UI/atoms/Time/Time.tsx
+++ b/src/components/UI/atoms/Time/Time.tsx
@@ -4,12 +4,13 @@ import moment from 'moment';
 
 export interface TimeProps {
   time: Date;
+  exactTime?: boolean;
 }
 
-const Time = ({ time }: TimeProps) => {
+const Time = ({ time, exactTime }: TimeProps) => {
   return (
     <>
-      <StyledTime>{moment(time).fromNow()}</StyledTime>
+      <StyledTime>{exactTime ? moment(time).format('a hh:mm') : moment(time).fromNow()}</StyledTime>
     </>
   );
 };

--- a/src/components/UI/molecules/MessagesPerMinute/MessagesPerMinute.stories.tsx
+++ b/src/components/UI/molecules/MessagesPerMinute/MessagesPerMinute.stories.tsx
@@ -1,0 +1,45 @@
+import { Meta, Story } from '@storybook/react';
+import MessagesPerMinute, { MessagesPerMinuteProps } from './MessagesPerMinute';
+
+export default {
+  title: 'Molecules/MessagesPerMinute',
+  component: MessagesPerMinute,
+} as Meta;
+
+const Template: Story<MessagesPerMinuteProps> = (args) => (
+  <>
+    <MessagesPerMinute {...args}></MessagesPerMinute>
+  </>
+);
+
+export const Me = Template.bind({});
+Me.args = {
+  chats: [
+    {
+      sender: 'me',
+      message: '아 이미 구매했어요 ㅠㅠ 죄송합니당 ㅜㅜㅜㅜ',
+      createdAt: new Date(),
+    },
+    {
+      sender: 'me',
+      message: '다음 번에 꼭 같이 거래해요~!',
+      createdAt: new Date(),
+    },
+  ],
+};
+
+export const You = Template.bind({});
+You.args = {
+  chats: [
+    {
+      sender: 'you',
+      message: '아 이미 구매했어요 ㅠㅠ 죄송합니당 ㅜㅜㅜㅜ',
+      createdAt: new Date(),
+    },
+    {
+      sender: 'you',
+      message: '다음 번에 꼭 같이 거래해요~!',
+      createdAt: new Date(),
+    },
+  ],
+};

--- a/src/components/UI/molecules/MessagesPerMinute/MessagesPerMinute.tsx
+++ b/src/components/UI/molecules/MessagesPerMinute/MessagesPerMinute.tsx
@@ -1,0 +1,36 @@
+import ChatMessage from '@atoms/ChatMessage/ChatMessage';
+import Image from '@atoms/Image/Image';
+import { MessagesPerMinuteStyled } from './MessagesPerMinuteStyled';
+
+export interface IChat {
+  sender: 'me' | 'you'; //보낸사람 정보. 일단은 me, you로만 구분
+  message: string;
+  createdAt: Date;
+}
+
+export interface MessagesPerMinuteProps {
+  chats: IChat[];
+}
+
+const MessagesPerMinute = (props: MessagesPerMinuteProps) => {
+  return (
+    <>
+      <MessagesPerMinuteStyled>
+        {props.chats[0].sender === 'you' ? (
+          <Image
+            imgUrl="https://img1.cgtrader.com/items/3095532/6fb947cfc0/large/hello-kitty-sanrio-3d-model-low-poly-obj-ztl.jpg"
+            width="33px"
+            height="33px"
+            borderRedius="50%"
+          />
+        ) : null}
+        <div className="messages-wrap">
+          {props.chats.map((chat, idx) => (
+            <ChatMessage key={idx} chat={chat} minute={props.chats.length === idx + 1 ? true : false} />
+          ))}
+        </div>
+      </MessagesPerMinuteStyled>
+    </>
+  );
+};
+export default MessagesPerMinute;

--- a/src/components/UI/molecules/MessagesPerMinute/MessagesPerMinuteStyled.tsx
+++ b/src/components/UI/molecules/MessagesPerMinute/MessagesPerMinuteStyled.tsx
@@ -1,0 +1,10 @@
+import styled from '@emotion/styled';
+
+export const MessagesPerMinuteStyled = styled.div`
+  display: flex;
+  gap: 5px;
+  margin-bottom: 5px;
+  .messages-wrap {
+    flex: 1;
+  }
+`;


### PR DESCRIPTION
```
[
  {sender, message, createdAt},
  {sender, message, createdAt},
  {sender, message, createdAt},
  {sender, message, createdAt}, ....
]
```
서버 쪽 코드 보니까 채팅 메세지 대략 이런 느낌인거 같아서 **MessagesPerMinute에는 sender와 createdAt이 동일한 메세지만 넘어온다고 가정**하고 만들었습니당. 눈에 보이는 것만 해서 나중에 수정해야 될 거 같아융

![image](https://user-images.githubusercontent.com/67870795/169464752-84862a59-e439-4e57-a645-96fa423ffd62.png)
그리고 채팅에는 위 사진처럼 Time이 "몇 분 전" 대신 정확한 시간으로 나오길래 Time에 props 추가해서 수정해줬슴다

