### PR TITLE
Issue/#69

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import ProductDetailPage from 'pages/ProductDetailPage/ProductDetailPage';
 
 import NewProductPage from 'pages/NewProductPage/NewProductPage';
 import CategotyPage from 'pages/CategotyPage/CategotyPage';
+import ChatRoomPage from 'pages/ChatRoomPage/ChatRoomPage';
 
 function App() {
   return (
@@ -29,6 +30,9 @@ function App() {
           </Route>
           <Route path="/product">
             <Route path="detail" element={<ProductDetailPage />} />
+          </Route>
+          <Route path="/chat">
+            <Route path="room" element={<ChatRoomPage />} />
           </Route>
         </Routes>
       </BrowserRouter>

--- a/src/components/UI/atoms/ChatMessage/ChatMessage.stories.tsx
+++ b/src/components/UI/atoms/ChatMessage/ChatMessage.stories.tsx
@@ -19,6 +19,7 @@ Me.args = {
     message: '아 이미 구매했어요 ㅠㅠ 죄송합니당 ㅜㅜㅜㅜ',
     createdAt: new Date(),
   },
+  isShowImage: false,
 };
 
 export const You = Template.bind({});
@@ -28,6 +29,7 @@ You.args = {
     message: '아 이미 구매했어요 ㅠㅠ 죄송합니당 ㅜㅜㅜㅜ',
     createdAt: new Date(),
   },
+  isShowImage: true,
 };
 
 export const MeWithTime = Template.bind({});
@@ -38,6 +40,7 @@ MeWithTime.args = {
     createdAt: new Date(),
   },
   minute: true,
+  isShowImage: false,
 };
 
 export const YouWithTime = Template.bind({});
@@ -48,4 +51,5 @@ YouWithTime.args = {
     createdAt: new Date(),
   },
   minute: true,
+  isShowImage: true,
 };

--- a/src/components/UI/atoms/ChatMessage/ChatMessage.tsx
+++ b/src/components/UI/atoms/ChatMessage/ChatMessage.tsx
@@ -1,16 +1,26 @@
 import { ChatMessageStyled } from './ChatMessageStyled';
 import Time from '@atoms/Time/Time';
 import { IChat } from 'interfaces/Chat.interface';
+import Image from '@atoms/Image/Image';
 
 export interface ChatMessageProps {
   minute?: boolean; //해당 분에 마지막인지 아닌지 (마지막이면 Time 보여줌)
   chat: IChat;
+  isShowImage: boolean;
 }
 
-const ChatMessage: React.FC<ChatMessageProps> = ({ minute, chat }, props) => {
+const ChatMessage: React.FC<ChatMessageProps> = ({ isShowImage, minute, chat }, props) => {
   return (
     <>
-      <ChatMessageStyled {...props}>
+      <ChatMessageStyled {...props} isShowImage={isShowImage} chat={chat}>
+        {isShowImage ? (
+          <Image
+            imgUrl="https://img1.cgtrader.com/items/3095532/6fb947cfc0/large/hello-kitty-sanrio-3d-model-low-poly-obj-ztl.jpg"
+            width="33px"
+            height="33px"
+            borderRedius="50%"
+          />
+        ) : null}
         {chat.sender === 'me' ? (
           <div className="message-container justify-end">
             {minute ? <Time time={chat.createdAt} exactTime={true} /> : null}

--- a/src/components/UI/atoms/ChatMessage/ChatMessageStyled.tsx
+++ b/src/components/UI/atoms/ChatMessage/ChatMessageStyled.tsx
@@ -1,37 +1,44 @@
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { ChatMessageProps } from './ChatMessage';
 
 export const ChatMessageStyled = styled.div<ChatMessageProps>`
-  .message-container {
-    display: flex;
-    flex-direction: row;
-    align-items: flex-end;
-    margin-bottom: 3px;
-    gap: 3px;
-  }
-  .justify-end {
-    justify-content: flex-end;
-  }
-  .justify-start {
-    justify-content: flex-start;
-  }
-
-  .message-text {
-    display: inline-block;
-    border: none;
-    border-radius: 15px;
-    padding: 10px;
-    width: auto;
-    max-width: 80%;
-    font-size: 0.9rem;
-    word-wrap: break-word;
-  }
-  .me {
-    background: ${(props) => props.theme.mainColor};
-    color: white;
-  }
-  .you {
-    background: ${(props) => props.theme.$black20};
-    color: black;
-  }
+  ${(props) => {
+    return css`
+      display: ${props.isShowImage && 'flex'};
+      gap: ${props.isShowImage && '10px'};
+      margin-left: ${!props.isShowImage && props.chat.sender === 'you' ? '43px' : '0px'};
+      .message-container {
+        display: flex;
+        flex-direction: row;
+        align-items: flex-end;
+        margin-bottom: 3px;
+        gap: 3px;
+      }
+      .justify-end {
+        justify-content: flex-end;
+      }
+      .justify-start {
+        justify-content: flex-start;
+      }
+      .message-text {
+        display: inline-block;
+        border: none;
+        border-radius: 15px;
+        padding: 10px;
+        width: auto;
+        max-width: 80%;
+        font-size: 0.9rem;
+        word-wrap: break-word;
+      }
+      .me {
+        background: ${props.theme.mainColor};
+        color: white;
+      }
+      .you {
+        background: ${props.theme.$black20};
+        color: black;
+      }
+    `;
+  }}
 `;

--- a/src/components/UI/atoms/Timeline/Timeline.stories.tsx
+++ b/src/components/UI/atoms/Timeline/Timeline.stories.tsx
@@ -14,5 +14,5 @@ const Template: Story<TimelineProps> = (args) => (
 
 export const Default = Template.bind({});
 Default.args = {
-  time: new Date(),
+  time: '2022년 12월 2일',
 };

--- a/src/components/UI/atoms/Timeline/Timeline.tsx
+++ b/src/components/UI/atoms/Timeline/Timeline.tsx
@@ -3,7 +3,7 @@ import 'moment/locale/ko';
 import moment from 'moment';
 
 export interface TimelineProps {
-  time: Date;
+  time: string;
 }
 
 const Timeline = ({ time }: TimelineProps) => {
@@ -11,7 +11,7 @@ const Timeline = ({ time }: TimelineProps) => {
     <>
       <TimelineStyled>
         <div className="timeline_bar"></div>
-        <div className="timeline_time">{moment(time).format('YYYY월 M월 DD일')}</div>
+        <div className="timeline_time">{time}</div>
         <div className="timeline_bar"></div>
       </TimelineStyled>
     </>

--- a/src/components/UI/atoms/Timeline/Timeline.tsx
+++ b/src/components/UI/atoms/Timeline/Timeline.tsx
@@ -1,6 +1,4 @@
 import { StickyHeader, TimelineStyled } from './TimelineStyled';
-import 'moment/locale/ko';
-import moment from 'moment';
 
 export interface TimelineProps {
   time: string;
@@ -8,13 +6,13 @@ export interface TimelineProps {
 
 const Timeline = ({ time }: TimelineProps) => {
   return (
-    <StickyHeader>
-      <TimelineStyled>
-        <div className="timeline_bar"></div>
-        <div className="timeline_time">{time}</div>
-        <div className="timeline_bar"></div>
-      </TimelineStyled>
-    </StickyHeader>
+    // <StickyHeader>
+    <TimelineStyled>
+      <div className="timeline_bar"></div>
+      <div className="timeline_time">{time}</div>
+      <div className="timeline_bar"></div>
+    </TimelineStyled>
+    // </StickyHeader>
   );
 };
 

--- a/src/components/UI/atoms/Timeline/Timeline.tsx
+++ b/src/components/UI/atoms/Timeline/Timeline.tsx
@@ -1,4 +1,4 @@
-import { TimelineStyled } from './TimelineStyled';
+import { StickyHeader, TimelineStyled } from './TimelineStyled';
 import 'moment/locale/ko';
 import moment from 'moment';
 
@@ -8,13 +8,13 @@ export interface TimelineProps {
 
 const Timeline = ({ time }: TimelineProps) => {
   return (
-    <>
+    <StickyHeader>
       <TimelineStyled>
         <div className="timeline_bar"></div>
         <div className="timeline_time">{time}</div>
         <div className="timeline_bar"></div>
       </TimelineStyled>
-    </>
+    </StickyHeader>
   );
 };
 

--- a/src/components/UI/atoms/Timeline/TimelineStyled.tsx
+++ b/src/components/UI/atoms/Timeline/TimelineStyled.tsx
@@ -7,7 +7,6 @@ export const TimelineStyled = styled.div`
       width: 100%;
       display: flex;
       align-items: center;
-      margin-bottom: 30px;
       .timeline_bar {
         flex: 1;
         height: 1px;
@@ -17,6 +16,19 @@ export const TimelineStyled = styled.div`
         margin: 0 5px;
         color: ${props.theme.$black50};
       }
+    `;
+  }}
+`;
+
+export const StickyHeader = styled.header`
+  ${(props) => {
+    return css`
+      /* width: 100%; */
+      display: flex;
+      align-items: center;
+      height: 100%;
+      position: sticky;
+      top: 10px;
     `;
   }}
 `;

--- a/src/components/UI/atoms/Timeline/TimelineStyled.tsx
+++ b/src/components/UI/atoms/Timeline/TimelineStyled.tsx
@@ -7,6 +7,7 @@ export const TimelineStyled = styled.div`
       width: 100%;
       display: flex;
       align-items: center;
+      justify-content: center;
       .timeline_bar {
         flex: 1;
         height: 1px;
@@ -23,12 +24,11 @@ export const TimelineStyled = styled.div`
 export const StickyHeader = styled.header`
   ${(props) => {
     return css`
-      /* width: 100%; */
       display: flex;
       align-items: center;
       height: 100%;
       position: sticky;
-      top: 10px;
+      top: 120px;
     `;
   }}
 `;

--- a/src/components/UI/molecules/ChatTabBar/ChatTabBarStyled.tsx
+++ b/src/components/UI/molecules/ChatTabBar/ChatTabBarStyled.tsx
@@ -1,14 +1,15 @@
-import styled from "@emotion/styled";
+import styled from '@emotion/styled';
 
 export const ChatTabBarStyled = styled.nav`
   width: 100%;
-  position: fixed;
+  /* position: fixed;
   left: 0;
   top: 0;
-  z-index: 99999;
+  z-index: 99999; */
   display: flex;
   border-bottom: 1px solid ${(props) => props.theme.$black20};
   padding: 10px 15px;
+  background-color: #fff;
   svg {
     fill: black;
     stroke: black;

--- a/src/components/UI/molecules/MessagesPerMinute/MessagesPerMinute.stories.tsx
+++ b/src/components/UI/molecules/MessagesPerMinute/MessagesPerMinute.stories.tsx
@@ -14,32 +14,26 @@ const Template: Story<MessagesPerMinuteProps> = (args) => (
 
 export const Me = Template.bind({});
 Me.args = {
-  chats: [
-    {
-      sender: 'me',
-      message: '아 이미 구매했어요 ㅠㅠ 죄송합니당 ㅜㅜㅜㅜ',
-      createdAt: new Date(),
-    },
-    {
-      sender: 'me',
-      message: '다음 번에 꼭 같이 거래해요~!',
-      createdAt: new Date(),
-    },
-  ],
+  chats: {
+    '03:24': [
+      {
+        sender: 'me',
+        message: '아 이미 구매했어요 ㅠㅠ 죄송합니당 ㅜㅜㅜㅜ',
+        createdAt: new Date(),
+      },
+    ],
+  },
 };
 
 export const You = Template.bind({});
 You.args = {
-  chats: [
-    {
-      sender: 'you',
-      message: '아 이미 구매했어요 ㅠㅠ 죄송합니당 ㅜㅜㅜㅜ',
-      createdAt: new Date(),
-    },
-    {
-      sender: 'you',
-      message: '다음 번에 꼭 같이 거래해요~!',
-      createdAt: new Date(),
-    },
-  ],
+  chats: {
+    '03:24': [
+      {
+        sender: 'you',
+        message: '아 이미 구매했어요 ㅠㅠ 죄송합니당 ㅜㅜㅜㅜ',
+        createdAt: new Date(),
+      },
+    ],
+  },
 };

--- a/src/components/UI/molecules/MessagesPerMinute/MessagesPerMinute.tsx
+++ b/src/components/UI/molecules/MessagesPerMinute/MessagesPerMinute.tsx
@@ -1,30 +1,45 @@
 import ChatMessage from '@atoms/ChatMessage/ChatMessage';
 import Image from '@atoms/Image/Image';
 import { IChat } from 'interfaces/Chat.interface';
+import { makeChatMinutesSection } from 'utils/chatSection';
 import { MessagesPerMinuteStyled } from './MessagesPerMinuteStyled';
 
 export interface MessagesPerMinuteProps {
   chats: IChat[];
 }
 
-const MessagesPerMinute = (props: MessagesPerMinuteProps) => {
+const MessagesPerMinute = ({ chats }: MessagesPerMinuteProps) => {
+  const section = makeChatMinutesSection(chats);
+  const isEndMessage = (sender: string, chatMessages: IChat[], currentIndex: number) => {
+    return (
+      (sender === 'you' && chatMessages.length === currentIndex + 1) ||
+      (sender === 'me' && chatMessages.length === currentIndex + 1) ||
+      (sender === 'you' && chatMessages.length === currentIndex + 1) ||
+      (sender === 'you' && chatMessages[currentIndex + 1] && chatMessages[currentIndex + 1].sender === 'me') ||
+      (sender === 'me' && chatMessages[currentIndex + 1] && chatMessages[currentIndex + 1].sender === 'you')
+    );
+  };
   return (
     <>
-      <MessagesPerMinuteStyled>
-        {props.chats[0].sender === 'you' ? (
-          <Image
-            imgUrl="https://img1.cgtrader.com/items/3095532/6fb947cfc0/large/hello-kitty-sanrio-3d-model-low-poly-obj-ztl.jpg"
-            width="33px"
-            height="33px"
-            borderRedius="50%"
-          />
-        ) : null}
-        <div className="messages-wrap">
-          {props.chats.map((chat, idx) => (
-            <ChatMessage key={idx} chat={chat} minute={props.chats.length === idx + 1 ? true : false} />
-          ))}
-        </div>
-      </MessagesPerMinuteStyled>
+      {Object.entries(section).map(([date, chatMessages]) => (
+        <MessagesPerMinuteStyled>
+          <div className="messages-wrap">
+            {chatMessages.map((chat, idx) => (
+              <>
+                {chat.sender === 'you' && idx === 0 ? (
+                  <Image
+                    imgUrl="https://img1.cgtrader.com/items/3095532/6fb947cfc0/large/hello-kitty-sanrio-3d-model-low-poly-obj-ztl.jpg"
+                    width="33px"
+                    height="33px"
+                    borderRedius="50%"
+                  />
+                ) : null}
+                <ChatMessage key={idx} chat={chat} minute={isEndMessage(chat.sender, chatMessages, idx)} />
+              </>
+            ))}
+          </div>
+        </MessagesPerMinuteStyled>
+      ))}
     </>
   );
 };

--- a/src/components/UI/molecules/MessagesPerMinute/MessagesPerMinute.tsx
+++ b/src/components/UI/molecules/MessagesPerMinute/MessagesPerMinute.tsx
@@ -1,5 +1,4 @@
 import ChatMessage from '@atoms/ChatMessage/ChatMessage';
-import Image from '@atoms/Image/Image';
 import { IChat } from 'interfaces/Chat.interface';
 import { MessagesPerMinuteStyled } from './MessagesPerMinuteStyled';
 
@@ -18,27 +17,22 @@ const MessagesPerMinute = ({ chats }: MessagesPerMinuteProps) => {
     );
   };
   return (
-    <>
+    <MessagesPerMinuteStyled>
       {Object.entries(chats).map(([date, chatMessages]) => (
-        <MessagesPerMinuteStyled key={chatMessages + date}>
+        <div key={chatMessages + date}>
           <div className="messages-wrap">
             {chatMessages.map((chat, idx) => (
-              <div key={chat.message + idx}>
-                {chat.sender === 'you' && idx === 0 ? (
-                  <Image
-                    imgUrl="https://img1.cgtrader.com/items/3095532/6fb947cfc0/large/hello-kitty-sanrio-3d-model-low-poly-obj-ztl.jpg"
-                    width="33px"
-                    height="33px"
-                    borderRedius="50%"
-                  />
-                ) : null}
-                <ChatMessage key={idx} chat={chat} minute={isEndMessage(chat.sender, chatMessages, idx)} />
-              </div>
+              <ChatMessage
+                key={idx}
+                isShowImage={chat.sender === 'you' && idx === 0}
+                chat={chat}
+                minute={isEndMessage(chat.sender, chatMessages, idx)}
+              />
             ))}
           </div>
-        </MessagesPerMinuteStyled>
+        </div>
       ))}
-    </>
+    </MessagesPerMinuteStyled>
   );
 };
 export default MessagesPerMinute;

--- a/src/components/UI/molecules/MessagesPerMinute/MessagesPerMinute.tsx
+++ b/src/components/UI/molecules/MessagesPerMinute/MessagesPerMinute.tsx
@@ -1,15 +1,13 @@
 import ChatMessage from '@atoms/ChatMessage/ChatMessage';
 import Image from '@atoms/Image/Image';
 import { IChat } from 'interfaces/Chat.interface';
-import { makeChatMinutesSection } from 'utils/chatSection';
 import { MessagesPerMinuteStyled } from './MessagesPerMinuteStyled';
 
 export interface MessagesPerMinuteProps {
-  chats: IChat[];
+  chats: { [key: string]: IChat[] };
 }
 
 const MessagesPerMinute = ({ chats }: MessagesPerMinuteProps) => {
-  const section = makeChatMinutesSection(chats);
   const isEndMessage = (sender: string, chatMessages: IChat[], currentIndex: number) => {
     return (
       (sender === 'you' && chatMessages.length === currentIndex + 1) ||
@@ -21,11 +19,11 @@ const MessagesPerMinute = ({ chats }: MessagesPerMinuteProps) => {
   };
   return (
     <>
-      {Object.entries(section).map(([date, chatMessages]) => (
-        <MessagesPerMinuteStyled>
+      {Object.entries(chats).map(([date, chatMessages]) => (
+        <MessagesPerMinuteStyled key={chatMessages + date}>
           <div className="messages-wrap">
             {chatMessages.map((chat, idx) => (
-              <>
+              <div key={chat.message + idx}>
                 {chat.sender === 'you' && idx === 0 ? (
                   <Image
                     imgUrl="https://img1.cgtrader.com/items/3095532/6fb947cfc0/large/hello-kitty-sanrio-3d-model-low-poly-obj-ztl.jpg"
@@ -35,7 +33,7 @@ const MessagesPerMinute = ({ chats }: MessagesPerMinuteProps) => {
                   />
                 ) : null}
                 <ChatMessage key={idx} chat={chat} minute={isEndMessage(chat.sender, chatMessages, idx)} />
-              </>
+              </div>
             ))}
           </div>
         </MessagesPerMinuteStyled>

--- a/src/components/UI/molecules/MessagesPerMinute/MessagesPerMinuteStyled.tsx
+++ b/src/components/UI/molecules/MessagesPerMinute/MessagesPerMinuteStyled.tsx
@@ -1,9 +1,10 @@
 import styled from '@emotion/styled';
 
 export const MessagesPerMinuteStyled = styled.div`
+  padding: 20px 0 30px;
   display: flex;
-  gap: 5px;
-  margin-bottom: 5px;
+  flex-direction: column;
+  gap: 6px;
   .messages-wrap {
     flex: 1;
   }

--- a/src/components/UI/molecules/MessagesPerMinute/MessagesPerMinuteStyled.tsx
+++ b/src/components/UI/molecules/MessagesPerMinute/MessagesPerMinuteStyled.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 export const MessagesPerMinuteStyled = styled.div`
-  padding: 20px 0 30px;
+  padding: 20px 15px 30px;
   display: flex;
   flex-direction: column;
   gap: 6px;

--- a/src/components/UI/molecules/ProductInfoBox/ProductInfoBoxStyled.tsx
+++ b/src/components/UI/molecules/ProductInfoBox/ProductInfoBoxStyled.tsx
@@ -4,6 +4,7 @@ export const ProductInfoBoxStyled = styled.div`
   border-bottom: 1px solid ${(props) => props.theme.$black20};
   padding: 10px 20px;
   width: 100%;
+  background-color: #fff;
   .messageProduct_info {
     display: flex;
     .messageProduct_info-detail {

--- a/src/components/UI/organisms/MessageContainer/MessageContainer.tsx
+++ b/src/components/UI/organisms/MessageContainer/MessageContainer.tsx
@@ -3,7 +3,7 @@ import ChatSendBox from '@molecules/ChatSendBox/ChatSendBox';
 import MessagesPerMinute from '@molecules/MessagesPerMinute/MessagesPerMinute';
 import { IChat } from 'interfaces/Chat.interface';
 import { useEffect, useRef, useState } from 'react';
-import { makeChatDaySection } from 'utils/chatSection';
+import { makeChatDayAndMinutesSection, makeChatDaySection } from 'utils/chatSection';
 import { MessageContainerStyled } from './MessageContainerStyled';
 
 export interface MessageContainerProps {}
@@ -92,12 +92,13 @@ const MessageContainer = (props: MessageContainerProps) => {
   useEffect(() => {
     scrollToBottom();
   }, [chatMessages]);
-  const section = makeChatDaySection(dummyChats);
+  const section = makeChatDayAndMinutesSection(dummyChats);
+  makeChatDayAndMinutesSection(dummyChats);
   return (
     <>
       <MessageContainerStyled>
         {Object.entries(section).map(([date, chats]) => (
-          <div>
+          <div key={date + chats}>
             <Timeline time={date} />
             <MessagesPerMinute chats={chats} />
           </div>

--- a/src/components/UI/organisms/MessageContainer/MessageContainer.tsx
+++ b/src/components/UI/organisms/MessageContainer/MessageContainer.tsx
@@ -3,6 +3,7 @@ import ChatSendBox from '@molecules/ChatSendBox/ChatSendBox';
 import MessagesPerMinute from '@molecules/MessagesPerMinute/MessagesPerMinute';
 import { IChat } from 'interfaces/Chat.interface';
 import { useEffect, useRef, useState } from 'react';
+import { makeChatDaySection } from 'utils/chatSection';
 import { MessageContainerStyled } from './MessageContainerStyled';
 
 export interface MessageContainerProps {}
@@ -10,7 +11,57 @@ export interface MessageContainerProps {}
 const dummyChats: IChat[] = [
   {
     sender: 'you',
+    message: '아 이미 구매했어요 ㅠㅠ 죄송합니당 ㅜㅜsssㅜㅜ',
+    createdAt: new Date(2021, 11, 17, 3, 24, 0),
+  },
+  {
+    sender: 'you',
+    message: '아 이미 구매했어요 ㅠㅠ 죄송합니당 ㅜㅜsssㅜㅜ',
+    createdAt: new Date(2021, 11, 24, 3, 24, 0),
+  },
+  {
+    sender: 'you',
+    message: '아 이미 구매했어요 ㅠㅠ 죄송합니당 ㅜㅜsssㅜㅜ',
+    createdAt: new Date(2021, 11, 24, 3, 24, 0),
+  },
+  {
+    sender: 'you',
+    message: '다음 번에 꼭 같이 거래해요~!',
+    createdAt: new Date(2022, 5, 1, 2, 24, 0),
+  },
+  {
+    sender: 'you',
+    message: '다음 번에 꼭 같이 거래해요~!',
+    createdAt: new Date(2022, 5, 1, 2, 24, 0),
+  },
+  {
+    sender: 'you',
+    message: '다음 번에 꼭 같이 거래해요~!',
+    createdAt: new Date(2022, 5, 1, 2, 24, 0),
+  },
+  {
+    sender: 'you',
     message: '아 이미 구매했어요 ㅠㅠ 죄송합니당 ㅜㅜㅜㅜ',
+    createdAt: new Date(2022, 5, 1, 2, 29, 0),
+  },
+  {
+    sender: 'me',
+    message: '다음 번에 꼭 같이 거래해요~!',
+    createdAt: new Date(2022, 5, 1, 2, 34, 0),
+  },
+  {
+    sender: 'me',
+    message: '다음 번에 꼭 같이 거래해요~!',
+    createdAt: new Date(2022, 5, 1, 2, 34, 0),
+  },
+  {
+    sender: 'me',
+    message: '다음 번에 꼭 같이 거래해요~!',
+    createdAt: new Date(2022, 5, 1, 2, 48, 0),
+  },
+  {
+    sender: 'you',
+    message: '다음 번에 꼭 같이 거래해요~!',
     createdAt: new Date(),
   },
   {
@@ -18,12 +69,9 @@ const dummyChats: IChat[] = [
     message: '다음 번에 꼭 같이 거래해요~!',
     createdAt: new Date(),
   },
-];
-
-const dummyChats2: IChat[] = [
   {
     sender: 'me',
-    message: '아 이미 구매했어요 ㅠㅠ 죄송합니당 ㅜㅜㅜㅜ',
+    message: '다음 번에 꼭 같이 거래해요~!',
     createdAt: new Date(),
   },
   {
@@ -44,19 +92,16 @@ const MessageContainer = (props: MessageContainerProps) => {
   useEffect(() => {
     scrollToBottom();
   }, [chatMessages]);
-
+  const section = makeChatDaySection(dummyChats);
   return (
     <>
       <MessageContainerStyled>
-        <Timeline time={new Date()} />
-        <div className="messages">
-          {chatMessages.map(() => (
-            <>
-              <MessagesPerMinute chats={dummyChats} />
-              <MessagesPerMinute chats={dummyChats2} />
-            </>
-          ))}
-        </div>
+        {Object.entries(section).map(([date, chats]) => (
+          <div>
+            <Timeline time={date} />
+            <MessagesPerMinute chats={chats} />
+          </div>
+        ))}
         <div ref={messagesEnd}></div>
         <ChatSendBox onClickSend={() => setChatMessages((prev) => [...prev, 1])} />
       </MessageContainerStyled>

--- a/src/components/UI/organisms/MessageContainer/MessageContainer.tsx
+++ b/src/components/UI/organisms/MessageContainer/MessageContainer.tsx
@@ -83,15 +83,11 @@ const dummyChats: IChat[] = [
 
 const MessageContainer = (props: MessageContainerProps) => {
   const messagesEnd = useRef<HTMLDivElement>(null);
-  const [chatMessages, setChatMessages] = useState<number[]>([1, 2]);
   const scrollToBottom = () => {
     if (messagesEnd.current) {
       messagesEnd.current.scrollIntoView({ behavior: 'smooth' });
     }
   };
-  useEffect(() => {
-    scrollToBottom();
-  }, [chatMessages]);
   const chatDayAndMinutesSection = makeChatDayAndMinutesSection(dummyChats);
   return (
     <>
@@ -103,7 +99,7 @@ const MessageContainer = (props: MessageContainerProps) => {
           </div>
         ))}
         <div ref={messagesEnd}></div>
-        <ChatSendBox onClickSend={() => setChatMessages((prev) => [...prev, 1])} />
+        <ChatSendBox onClickSend={() => scrollToBottom()} />
       </MessageContainerStyled>
     </>
   );

--- a/src/components/UI/organisms/MessageContainer/MessageContainer.tsx
+++ b/src/components/UI/organisms/MessageContainer/MessageContainer.tsx
@@ -3,7 +3,7 @@ import ChatSendBox from '@molecules/ChatSendBox/ChatSendBox';
 import MessagesPerMinute from '@molecules/MessagesPerMinute/MessagesPerMinute';
 import { IChat } from 'interfaces/Chat.interface';
 import { useEffect, useRef, useState } from 'react';
-import { makeChatDayAndMinutesSection, makeChatDaySection } from 'utils/chatSection';
+import { makeChatDayAndMinutesSection } from 'utils/chatSection';
 import { MessageContainerStyled } from './MessageContainerStyled';
 
 export interface MessageContainerProps {}
@@ -92,12 +92,11 @@ const MessageContainer = (props: MessageContainerProps) => {
   useEffect(() => {
     scrollToBottom();
   }, [chatMessages]);
-  const section = makeChatDayAndMinutesSection(dummyChats);
-  makeChatDayAndMinutesSection(dummyChats);
+  const chatDayAndMinutesSection = makeChatDayAndMinutesSection(dummyChats);
   return (
     <>
       <MessageContainerStyled>
-        {Object.entries(section).map(([date, chats]) => (
+        {Object.entries(chatDayAndMinutesSection).map(([date, chats]) => (
           <div key={date + chats}>
             <Timeline time={date} />
             <MessagesPerMinute chats={chats} />

--- a/src/components/UI/organisms/MessageContainer/MessageContainerStyled.tsx
+++ b/src/components/UI/organisms/MessageContainer/MessageContainerStyled.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
 
 export const MessageContainerStyled = styled.div`
-  margin-bottom: 50px;
+  padding: 120px 0 40px;
 `;

--- a/src/components/templates/Home/Home.tsx
+++ b/src/components/templates/Home/Home.tsx
@@ -6,7 +6,7 @@ import ProductBoxes from '../../UI/organisms/ProductBoxes/ProductBoxes';
 import TabBar from '../../UI/organisms/TabBar/TabBar';
 import { StyledHome } from './HomeStyled';
 
-const dummyProduct: Pick<
+export const dummyProduct: Pick<
   IProduct,
   'id' | 'thumb_nail_image' | 'title' | 'location' | 'created_at' | 'price' | 'likes'
 > = {

--- a/src/pages/ChatRoomPage/ChatRoomPage.tsx
+++ b/src/pages/ChatRoomPage/ChatRoomPage.tsx
@@ -7,7 +7,7 @@ import { ChatRoomPageStyled } from './ChatRoomPageStyled';
 const ChatRoomPage = () => {
   return (
     <ChatRoomPageStyled>
-      <div className="chatRomm_productInfoBox">
+      <div className="chatRoom_fixed">
         <ChatTabBar userDetail={{ nickname: '이재훈', manner: 46 }} />
         <ProductInfoBox product={dummyProduct} />
       </div>

--- a/src/pages/ChatRoomPage/ChatRoomPage.tsx
+++ b/src/pages/ChatRoomPage/ChatRoomPage.tsx
@@ -1,0 +1,19 @@
+import ChatTabBar from '@molecules/ChatTabBar/ChatTabBar';
+import ProductInfoBox from '@molecules/ProductInfoBox/ProductInfoBox';
+import MessageContainer from '@organisms/MessageContainer/MessageContainer';
+import { dummyProduct } from 'pages/ProductDetailPage/ProductDetailPage';
+import { ChatRoomPageStyled } from './ChatRoomPageStyled';
+
+const ChatRoomPage = () => {
+  return (
+    <ChatRoomPageStyled>
+      <div className="chatRomm_productInfoBox">
+        <ChatTabBar userDetail={{ nickname: '이재훈', manner: 46 }} />
+        <ProductInfoBox product={dummyProduct} />
+      </div>
+      <MessageContainer />
+    </ChatRoomPageStyled>
+  );
+};
+
+export default ChatRoomPage;

--- a/src/pages/ChatRoomPage/ChatRoomPageStyled.tsx
+++ b/src/pages/ChatRoomPage/ChatRoomPageStyled.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 export const ChatRoomPageStyled = styled.div`
-  .chatRomm_productInfoBox {
+  .chatRoom_fixed {
     position: fixed;
     width: 100%;
     left: 0;

--- a/src/pages/ChatRoomPage/ChatRoomPageStyled.tsx
+++ b/src/pages/ChatRoomPage/ChatRoomPageStyled.tsx
@@ -1,0 +1,11 @@
+import styled from '@emotion/styled';
+
+export const ChatRoomPageStyled = styled.div`
+  .chatRomm_productInfoBox {
+    position: fixed;
+    width: 100%;
+    left: 0;
+    top: 0;
+    z-index: 99999;
+  }
+`;

--- a/src/pages/ProductDetailPage/ProductDetailPage.tsx
+++ b/src/pages/ProductDetailPage/ProductDetailPage.tsx
@@ -15,7 +15,7 @@ const dummyUser: IUser = {
   manner: 38.6,
 };
 
-const dummyProduct: IProductWithUser = {
+export const dummyProduct: IProductWithUser = {
   id: 1,
   title: '아이폰 삽니다',
   category: '디지털기기',
@@ -31,7 +31,8 @@ const dummyProduct: IProductWithUser = {
   ],
   location: '서울 강남',
   price: 6000,
-  thumb_nail_image: '',
+  thumb_nail_image:
+    'https://play-lh.googleusercontent.com/6Adeoocj4FktXRmkcFY8j6sknDBK_eoCjsMv6EPJI_ZLhLUeAmZH_r5QxKBBa8xoxgni',
   likes: [],
   state: ProductState.FOR_SALE,
   user: dummyUser,

--- a/src/utils/chatSection.ts
+++ b/src/utils/chatSection.ts
@@ -8,11 +8,7 @@ export function makeChatDayAndMinutesSection(chatList: IChat[]) {
     const day = moment(chat.createdAt).format('YYYY월 M월 DD일');
     const minutes = moment(chat.createdAt).format('hh:mm');
     if (day in section) {
-      if (minutes in section[day]) {
-        section[day][minutes].push(chat);
-      } else {
-        section[day][minutes] = [chat];
-      }
+      (minutes in section[day] && section[day][minutes].push(chat)) || (section[day][minutes] = [chat]);
     } else {
       section[day] = {};
       section[day][minutes] = [chat];

--- a/src/utils/chatSection.ts
+++ b/src/utils/chatSection.ts
@@ -28,3 +28,23 @@ export function makeChatMinutesSection(chatList: IChat[]) {
   });
   return section;
 }
+
+export function makeChatDayAndMinutesSection(chatList: IChat[]) {
+  const section: { [key: string]: { [key: string]: IChat[] } } = {};
+  chatList.forEach((chat) => {
+    const monthDate = moment(chat.createdAt).format('YYYY월 M월 DD일');
+    const minutes = moment(chat.createdAt).format('hh:mm');
+    if (monthDate in section) {
+      if (minutes in section[monthDate]) {
+        section[monthDate][minutes].push(chat);
+      } else {
+        section[monthDate][minutes] = [chat];
+      }
+    } else {
+      section[monthDate] = {};
+      section[monthDate][minutes] = [chat];
+    }
+  });
+  console.log(section);
+  return section;
+}

--- a/src/utils/chatSection.ts
+++ b/src/utils/chatSection.ts
@@ -2,49 +2,21 @@ import 'moment/locale/ko';
 import moment from 'moment';
 import { IChat } from 'interfaces/Chat.interface';
 
-export function makeChatDaySection(chatList: IChat[]) {
-  const section: { [key: string]: IChat[] } = {};
-  chatList.forEach((chat) => {
-    const monthDate = moment(chat.createdAt).format('YYYY월 M월 DD일');
-    const minutes = moment(chat.createdAt).format('hh:mm');
-    if (monthDate in section) {
-      section[monthDate].push(chat);
-    } else {
-      section[monthDate] = [chat];
-    }
-  });
-  return section;
-}
-
-export function makeChatMinutesSection(chatList: IChat[]) {
-  const section: { [key: string]: IChat[] } = {};
-  chatList.forEach((chat) => {
-    const minutes = moment(chat.createdAt).format('hh:mm');
-    if (minutes in section) {
-      section[minutes].push(chat);
-    } else {
-      section[minutes] = [chat];
-    }
-  });
-  return section;
-}
-
 export function makeChatDayAndMinutesSection(chatList: IChat[]) {
   const section: { [key: string]: { [key: string]: IChat[] } } = {};
   chatList.forEach((chat) => {
-    const monthDate = moment(chat.createdAt).format('YYYY월 M월 DD일');
+    const day = moment(chat.createdAt).format('YYYY월 M월 DD일');
     const minutes = moment(chat.createdAt).format('hh:mm');
-    if (monthDate in section) {
-      if (minutes in section[monthDate]) {
-        section[monthDate][minutes].push(chat);
+    if (day in section) {
+      if (minutes in section[day]) {
+        section[day][minutes].push(chat);
       } else {
-        section[monthDate][minutes] = [chat];
+        section[day][minutes] = [chat];
       }
     } else {
-      section[monthDate] = {};
-      section[monthDate][minutes] = [chat];
+      section[day] = {};
+      section[day][minutes] = [chat];
     }
   });
-  console.log(section);
   return section;
 }

--- a/src/utils/chatSection.ts
+++ b/src/utils/chatSection.ts
@@ -1,0 +1,30 @@
+import 'moment/locale/ko';
+import moment from 'moment';
+import { IChat } from 'interfaces/Chat.interface';
+
+export function makeChatDaySection(chatList: IChat[]) {
+  const section: { [key: string]: IChat[] } = {};
+  chatList.forEach((chat) => {
+    const monthDate = moment(chat.createdAt).format('YYYY월 M월 DD일');
+    const minutes = moment(chat.createdAt).format('hh:mm');
+    if (monthDate in section) {
+      section[monthDate].push(chat);
+    } else {
+      section[monthDate] = [chat];
+    }
+  });
+  return section;
+}
+
+export function makeChatMinutesSection(chatList: IChat[]) {
+  const section: { [key: string]: IChat[] } = {};
+  chatList.forEach((chat) => {
+    const minutes = moment(chat.createdAt).format('hh:mm');
+    if (minutes in section) {
+      section[minutes].push(chat);
+    } else {
+      section[minutes] = [chat];
+    }
+  });
+  return section;
+}


### PR DESCRIPTION
채팅 메시지 날짜별 / 분별로 나눠서 보이게 해줬습니다! 나름 깔끔하게 하려고 노력한건데 아직 제가 봐도 좀 지저분해 보이네요.. 
## 변경사항
- 해당 작업하면서 혜수님이 만드신 MessagesPerMinute, ChatMessage 수정했습니다 확인부탁드려요! MessagesPerMinute에 있던 Image컴포넌트를 ChatMessage로 옮겨줬는데 도저히 MessagesPerMinute에 Image가 있으면 css를 어떻게 짤지 생각이 안나ChatMessage로 옮겨줬습니다!
- 채팅 메시지 날짜별 / 분별로 나누는 함수를 작성해서 utils 폴더만들어서 넣어줬습니다! 더 좋은 폴더명이 있으면 그때 고칠게요!  나중에 api를 붙일때 hook으로 만들어야 할 수도 있을것 같네요
- 작업하면서 ChatRoomPage도 같이 만들어 줬습니다! 일단 ChatRoomPage에서 z-index가 필요한 컴포넌트는 99999로 해줬는데 혜수님이 z-index관련해서 theme만드셨다고 하셨으니 이것도 바꿔줘야 할것 같네요. 다른 작업할때 같이 바꾸겠습니다! 
- ChatRoomPage에 fixed되야할게 ChatTabBar / ProductInfoBox이렇게 두개가 있어서 따로 fixed하기보단 묶어서 하는게 나을것 같아ChatTabBar에 있던 z-index, fixed관련 css는 ChatRoomPage에서 만들어 줬습니다!  
closes #69 