### PR TITLE
Issue/#91 - 배포스크립트 적용

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,52 @@
+name: daangn-client
+
+on:
+  workflow_dispatch: # 수동으로 해당 workflow를 실행시키겠다는 뜻
+
+env: # 현재 스크립트에서 사용할 환경변수 정의
+  S3_BUCKET_NAME: cotchan-service-deploy
+  PROJECT_NAME: daangn-client
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout # 깃헙이 제공하는 워크스페이스 (이 workflow 를 실행하는 공간) 에서 내 저장소가 위치한 곳으로 이동
+        uses: actions/checkout@v3
+
+      #   - name: create env file # 깃헙 settings > secrets 에 올려놓은 비밀 값을 복사해 .env 파일로 생성
+      #     run: |
+      #       touch .env
+      #       echo "${{ secrets.ENV_PROD_VARS }}" >> .env
+
+      - name: Set up NPM 16 # npm 셋업
+        uses: actions/setup-node@v2
+        with:
+          node-version: "16.x"
+          registry-url: "https://npm.pkg.github.com"
+
+      - name: npm install
+        run: npm install
+        shell: bash
+
+      - name: Build with npm # 프로젝트 build
+        run: npm run build
+        shell: bash
+
+      - name: Make zip file
+        run: zip -r ./$GITHUB_SHA.zip .
+        shell: bash
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Upload to S3
+        run: aws s3 cp --region ap-northeast-2 ./$GITHUB_SHA.zip s3://$S3_BUCKET_NAME/$PROJECT_NAME/$GITHUB_SHA.zip
+
+      - name: Code Deploy
+        run: aws deploy create-deployment --application-name sandbox-client-service-deploy --deployment-config-name CodeDeployDefault.AllAtOnce --deployment-group-name sandbox --s3-location bucket=$S3_BUCKET_NAME,bundleType=zip,key=$PROJECT_NAME/$GITHUB_SHA.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM nginx
+
+# 해당 애플리케이션의 소스 코드가 이 디렉터리로 들어감
+WORKDIR /app
+
+COPY ./nginx/default.conf /etc/nginx/conf.d/default.conf
+
+COPY ./build /usr/share/nginx/html

--- a/appspec.yml
+++ b/appspec.yml
@@ -1,0 +1,18 @@
+version: 0.0
+os: linux
+files:
+  - source: / # 현재 프로젝트의 루트 경로
+    destination: /home/ubuntu/daangn-client/ # S3에서 받아올 프로젝트의 위치를 지정 (EC2 내부의 어떤 디렉토리에 전달 ?)
+    overwrite: yes # 덮어쓰기 할 것인지?
+
+permissions:
+  - object: /
+    pattern: '**'
+    owner: ubuntu
+    group: ubuntu
+
+hooks: # CodeDeploy의 배포에는 각 단계 별 수명 주기가 있는데, 수명 주기에 따라 원하는 스크립트를 수행가능
+  ApplicationStart:
+    - location: scripts/deploy.sh
+      timeout: 180
+      runas: ubuntu

--- a/docker-compose.blue.yml
+++ b/docker-compose.blue.yml
@@ -1,0 +1,21 @@
+version: "3"
+
+services:
+  frontend:
+    container_name: daangn-client-blue
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "3001:3000"
+    # 볼륨을 설정합니다.
+    volumes:
+      - /app/node_modules
+      - ./frontend:/app
+    # 리액트 애플리케이션에서 발생하는 버그 해결
+    stdin_open: true
+
+networks:
+  default:
+    external:
+      name: daangn_net

--- a/docker-compose.green.yml
+++ b/docker-compose.green.yml
@@ -1,0 +1,21 @@
+version: "3"
+
+services:
+  frontend:
+    container_name: daangn-client-green
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "3002:3000"
+    # 볼륨을 설정합니다.
+    volumes:
+      - /app/node_modules
+      - ./frontend:/app
+    # 리액트 애플리케이션에서 발생하는 버그 해결
+    stdin_open: true
+
+networks:
+  default:
+    external:
+      name: daangn_net

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,12 @@
+server {
+    listen 3000;
+
+    location / {
+        # HTML 파일이 위치할 루트 경로를 설정
+        root /usr/share/nginx/html;
+        # index 페이지의 파일명을 설정합니다.
+        index index.html index.htm;
+        # 리액트 라우터를 사용해 페이지를 이동할 때 이 부분이 필요합니다.
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/nginx/service-url-blue.inc
+++ b/nginx/service-url-blue.inc
@@ -1,0 +1,1 @@
+set $client_url http://127.0.0.1:3001;

--- a/nginx/service-url-green.inc
+++ b/nginx/service-url-green.inc
@@ -1,0 +1,1 @@
+set $client_url http://127.0.0.1:3002;

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+ABSPATH=$(readlink -f $0) # 현재 파일 위치 절대 경로로 받기
+ABSDIR=$(dirname $ABSPATH) # 현재 디렉토리 위치 
+SOURCE_REPOSITORY=$(dirname $ABSDIR) # 부모 디렉토리 위치 
+DOCKER_APP_NAME=daangn-client # DOCKER_APP_NAME에는 프로젝트명을 적는다.
+
+# Blue 를 기준으로 현재 떠있는 컨테이너를 한다.
+EXIST_BLUE=$(docker-compose -p ${DOCKER_APP_NAME}-blue -f ${SOURCE_REPOSITORY}/docker-compose.blue.yml ps | grep Up)
+
+# 컨테이너 스위칭
+if [ -z "$EXIST_BLUE" ]; then
+    echo "blue up"
+    docker-compose -p ${DOCKER_APP_NAME}-blue -f ${SOURCE_REPOSITORY}/docker-compose.blue.yml up --build -d
+    BEFORE_COMPOSE_COLOR="green"
+    AFTER_COMPOSE_COLOR="blue"
+else
+    echo "green up"
+    docker-compose -p ${DOCKER_APP_NAME}-green -f ${SOURCE_REPOSITORY}/docker-compose.green.yml up --build -d
+    BEFORE_COMPOSE_COLOR="blue"
+    AFTER_COMPOSE_COLOR="green"
+fi
+
+sleep 10
+
+# 새로운 컨테이너가 제대로 떴는지 확인
+EXIST_AFTER=$(docker-compose -p ${DOCKER_APP_NAME}-${AFTER_COMPOSE_COLOR} -f ${SOURCE_REPOSITORY}/docker-compose.${AFTER_COMPOSE_COLOR}.yml ps | grep Up)
+if [ -n "$EXIST_AFTER" ]; then
+    echo "nginx reload.."
+    # nginx.config를 컨테이너에 맞게 변경해주고 reload 한다
+    sudo cp ${SOURCE_REPOSITORY}/nginx/service-url-${AFTER_COMPOSE_COLOR}.inc /etc/nginx/conf.d/frontend-url.inc
+    sudo systemctl reload nginx
+
+    # 이전 컨테이너 종료
+    echo "$BEFORE_COMPOSE_COLOR down"
+    docker-compose -p ${DOCKER_APP_NAME}-${BEFORE_COMPOSE_COLOR} -f ${SOURCE_REPOSITORY}/docker-compose.${BEFORE_COMPOSE_COLOR}.yml down
+else
+    echo "> The new container did not run properly."
+    exit 1
+fi


### PR DESCRIPTION
- #91 

---

## 변경사항

- daangn-client를 docker 환경에서 무중단 배포할 수 있도록 아래 3가지 설정을 적용해두었습니다.
    - aws CodeDeploy
    - git-action
    - docker, docker-compose
- 배포 flow는 아래와 같습니다.
    1. git-action을 사용해서 npm run build
    2. build 완료된 정적 파일을 s3로 전달
    3. s3에서 CodeDeploy를 사용해서 배포 서버로 전달
    4. 배포 서버에서 CodeDeploy Agent가 실행되며 `appspec.yml` => `/scripts/deploy.sh` 실행
    5. 빌드 스크립트가 실행되면 배포 서버에서 Dockerfile / docker-compse.*.yml 을 읽어서 도커 환경에서 daangn-client 실행

## 기타

- 작업 마무리되실 때까지 별도 브랜치에서 작업하려고 했는데 daangn-client에서 `git-action`을 사용하려면 main 브랜치에 git-action 스크립트(`./github/workflows/deploy.yml`)가 적용되어 있어야 다른 브랜치에서도 사용이 가능합니다.
- 그래서 부득이하게 main에 PR 요청드린 점 양해부탁드려요.
